### PR TITLE
Fix manual sync of GPS from TSX

### DIFF
--- a/iOptronV3.cpp
+++ b/iOptronV3.cpp
@@ -1187,7 +1187,9 @@ int CiOptron::setLocation(float fLat, float fLong)
         //  This command sets the current longitude. Valid data range is [-64,800,000, +64,800,000].
         //  Note: East is positive, and the resolution is 0.01 arc-second.
 
-        snprintf(szCmd, SERIAL_BUFFER_SIZE, ":SLO%+09d#", ulLongToSend);
+        uint32_t ulLongToSend = fabs(fLong) * 60 * 60 * 100;
+
+        snprintf(szCmd, SERIAL_BUFFER_SIZE, ":SLO%c%08u#", fLong >= 0 ? '+' : '-', ulLongToSend);
 
 #if defined IOPTRON_DEBUG
         if (Logfile) {

--- a/iOptronV3.cpp
+++ b/iOptronV3.cpp
@@ -23,7 +23,7 @@ CiOptron::CiOptron() {
     getAtParkTimer.Reset();
 }
 
-#if defined IOPTRON_DEBUG && IOPTRON_DEBUG >= 2
+#if defined IOPTRON_DEBUG && IOPTRON_DEBUG >= 1
 void CiOptron::setLogFile(FILE *daFile) {
     Logfile = daFile;
     if (Logfile) {
@@ -50,7 +50,7 @@ int CiOptron::Connect(char *pszPort)
     int iBehavior, iDegreesPastMeridian, iDegreesAltLimit;
     int connectSpeed = 115200;  // default for CEM120xxx
 
-#if defined IOPTRON_DEBUG && IOPTRON_DEBUG >= 2
+#if defined IOPTRON_DEBUG && IOPTRON_DEBUG >= 1
     if (Logfile) {
         fprintf(Logfile, "[%s] CiOptron::Connect Called %s\n", getTimestamp(), pszPort);
         fflush(Logfile);
@@ -91,7 +91,7 @@ int CiOptron::Connect(char *pszPort)
         break;
     }
 
-#if defined IOPTRON_DEBUG && IOPTRON_DEBUG >= 2
+#if defined IOPTRON_DEBUG && IOPTRON_DEBUG >= 1
     if (Logfile) {
         fprintf(Logfile, "[%s] CiOptron::Connect connected at %d on %s\n", getTimestamp(), connectSpeed, pszPort);
         fflush(Logfile);
@@ -125,7 +125,7 @@ int CiOptron::Connect(char *pszPort)
 
 int CiOptron::Disconnect(void)
 {
-#if defined IOPTRON_DEBUG && IOPTRON_DEBUG >= 2
+#if defined IOPTRON_DEBUG && IOPTRON_DEBUG >= 1
     if (Logfile) {
         fprintf(Logfile, "[%s] CiOptron::Disconnect Called\n", getTimestamp());
         fflush(Logfile);
@@ -133,7 +133,7 @@ int CiOptron::Disconnect(void)
 #endif
 	if (m_bIsConnected) {
         if(m_pSerx){
-#if defined IOPTRON_DEBUG && IOPTRON_DEBUG >= 2
+#if defined IOPTRON_DEBUG && IOPTRON_DEBUG >= 1
             if (Logfile) {
                 fprintf(Logfile, "[%s] CiOptron::Disconnect closing serial port\n", getTimestamp());
                 fflush(Logfile);
@@ -1136,7 +1136,7 @@ int CiOptron::setLocation(float fLat, float fLong)
     unsigned long ulLatToSend;
     unsigned long ulLongToSend;
 
-#if defined IOPTRON_DEBUG && IOPTRON_DEBUG >= 2
+#if defined IOPTRON_DEBUG
     if (Logfile) {
         fprintf(Logfile, "[%s] [CiOptron::setLocation] called \n", getTimestamp());
         fflush(Logfile);
@@ -1146,21 +1146,21 @@ int CiOptron::setLocation(float fLat, float fLong)
     //  extracting lat:   m_fLat = ((atof(szTmp)-32400000)*0.01)/ 60.0 /60.0;
     ulLatToSend = (fLat * 60.0 * 60.0 / 0.01);
 
-#if defined IOPTRON_DEBUG && IOPTRON_DEBUG >= 2
+#ifdef IOPTRON_DEBUG
     if (Logfile) {
-        fprintf(Logfile, "[%s] [CiOptron::setLocation] setting Latitude from %f to iOptron value %u\n", getTimestamp(), m_fLat, ulLatToSend);
+        fprintf(Logfile, "[%s] [CiOptron::setLocation] setting Latitude from %f to iOptron value %lu\n", getTimestamp(), m_fLat, ulLatToSend);
         fflush(Logfile);
     }
 #endif
 
-    //  Command: “:SLAsTTTTTTTT#”
-    //  Response: “1”
+    //  Command: ":SLAsTTTTTTTT#"
+    //  Response: "1"
     //  This command sets the current latitude. Valid data range is [-32,400,000, +32,400,000].
     //  Note: North is positive, and the resolution is 0.01 arc-second.
 
     snprintf(szCmd, SERIAL_BUFFER_SIZE, ":SLA%+09d#", ulLatToSend);
 
-#if defined IOPTRON_DEBUG && IOPTRON_DEBUG >= 2
+#if defined IOPTRON_DEBUG
     if (Logfile) {
         fprintf(Logfile, "[%s] [CiOptron::setLocation] buffer to send for Lat to mount %s\n", getTimestamp(), szCmd);
         fflush(Logfile);
@@ -1175,21 +1175,21 @@ int CiOptron::setLocation(float fLat, float fLong)
         // extracing long:   m_fLong = (atof(szTmp)*0.01)/ 60.0 /60.0;
         ulLongToSend = (fLong * 60.0 * 60.0 / 0.01);
 
-#if defined IOPTRON_DEBUG && IOPTRON_DEBUG >= 2
+#if defined IOPTRON_DEBUG
         if (Logfile) {
-        fprintf(Logfile, "[%s] [CiOptron::setLocation] setting Longitude from %f to iOptron value %u\n", getTimestamp(), m_fLong, ulLongToSend);
+        fprintf(Logfile, "[%s] [CiOptron::setLocation] setting Longitude from %f to iOptron value %lu\n", getTimestamp(), m_fLong, ulLongToSend);
         fflush(Logfile);
     }
 #endif
         //
-        //  Command: “:SLOsTTTTTTTT#”
-        //  Response: “1”
+        //  Command: ":SLOsTTTTTTTT#"
+        //  Response: "1"
         //  This command sets the current longitude. Valid data range is [-64,800,000, +64,800,000].
         //  Note: East is positive, and the resolution is 0.01 arc-second.
 
         snprintf(szCmd, SERIAL_BUFFER_SIZE, ":SLO%+09d#", ulLongToSend);
 
-#if defined IOPTRON_DEBUG && IOPTRON_DEBUG >= 2
+#if defined IOPTRON_DEBUG
         if (Logfile) {
         fprintf(Logfile, "[%s] [CiOptron::setLocation] buffer to send for Long to mount %s\n", getTimestamp(), szCmd);
         fflush(Logfile);
@@ -1197,7 +1197,7 @@ int CiOptron::setLocation(float fLat, float fLong)
 #endif
         nErr = sendCommand(szCmd, szResp, 1);
 
-#if defined IOPTRON_DEBUG && IOPTRON_DEBUG >= 2
+#if defined IOPTRON_DEBUG
         if (Logfile) {
         fprintf(Logfile, "[%s] [CiOptron::setLocation] done, nErr = %i\n", getTimestamp(), nErr);
         fflush(Logfile);
@@ -2000,19 +2000,19 @@ int CiOptron::getInfoAndSettings()
     }
 #endif
 
-    memset(szTmp,0, SERIAL_BUFFER_SIZE);
+    memset(szTmp, 0, SERIAL_BUFFER_SIZE);
     memcpy(szTmp, szResp, 9);
-    m_fLong = (atof(szTmp)*0.01)/ 60.0 /60.0;
+    m_fLong = (atof(szTmp) * 0.01)/ 60.0 /60.0;
 
-    memset(szTmp,0, SERIAL_BUFFER_SIZE);
-    memcpy(szTmp, szResp+9, 8);
+    memset(szTmp, 0, SERIAL_BUFFER_SIZE);
+    memcpy(szTmp, szResp + 9, 8);
     m_fLat = ((atof(szTmp)-32400000)*0.01)/ 60.0 /60.0;
 
-    memset(szTmp,0, SERIAL_BUFFER_SIZE);
-    memcpy(szTmp, szResp+17, 1);
+    memset(szTmp, 0, SERIAL_BUFFER_SIZE);
+    memcpy(szTmp, szResp + 17, 1);
 #if defined IOPTRON_DEBUG && IOPTRON_DEBUG >= 2
     if (Logfile) {
-        fprintf(Logfile, "[%s] [CiOptron::getInfoAndSettings]  GPS status from mount returned is: %s, \n", szTmp);
+        fprintf(Logfile, "[%s] [CiOptron::getInfoAndSettings]  GPS status from mount returned is: %s, \n", getTimestamp(), szTmp);
         fflush(Logfile);
     }
 #endif

--- a/iOptronV3.cpp
+++ b/iOptronV3.cpp
@@ -849,7 +849,7 @@ int CiOptron::gotoZeroPosition() {
 
     int nErr = IOPTRON_OK;
     char szResp[SERIAL_BUFFER_SIZE];
-#if defined IOPTRON_DEBUG && IOPTRON_DEBUG >= 2
+#if defined IOPTRON_DEBUG
     if (Logfile) {
         fprintf(Logfile, "[%s] [CiOptron::gotoZeroPosition] called \n", getTimestamp());
         fflush(Logfile);
@@ -862,7 +862,7 @@ int CiOptron::gotoZeroPosition() {
     if (nErr)
         return nErr;
 
-#if defined IOPTRON_DEBUG && IOPTRON_DEBUG >= 2
+#if defined IOPTRON_DEBUG
     if (Logfile) {
         fprintf(Logfile, "[%s] [CiOptron::gotoZeroPosition] finished.  Result: %s\n", getTimestamp(), szResp);
         fflush(Logfile);
@@ -959,7 +959,7 @@ int CiOptron::findZeroPosition() {
 
     int nErr = IOPTRON_OK;
     char szResp[SERIAL_BUFFER_SIZE];
-#if defined IOPTRON_DEBUG && IOPTRON_DEBUG >= 2
+#if defined IOPTRON_DEBUG && IOPTRON_DEBUG >= 1
     if (Logfile) {
         fprintf(Logfile, "[%s] [CiOptron::calibrateZeroPosition] called \n", getTimestamp());
         fflush(Logfile);
@@ -969,7 +969,7 @@ int CiOptron::findZeroPosition() {
     // Find Zero position / home position
     nErr = sendCommand(":MSH#", szResp, 1);
 
-#if defined IOPTRON_DEBUG && IOPTRON_DEBUG >= 2
+#if defined IOPTRON_DEBUG && IOPTRON_DEBUG >= 1
     if (Logfile) {
         fprintf(Logfile, "[%s] [CiOptron::calibrateZeroPosition] finished.  Result: %s\n", getTimestamp(), szResp);
         fflush(Logfile);

--- a/iOptronV3.h
+++ b/iOptronV3.h
@@ -27,9 +27,9 @@
 #include "StopWatch.h"
 
 
-#define IOPTRON_DEBUG 1   // define this to have log files, 1 = bad stuff only, 2 and up.. full debug
+#define IOPTRON_DEBUG 0   // define this to have log files, 1 = bad stuff only, 2 and up.. full debug
 
-#define DRIVER_VERSION 1.11
+#define DRIVER_VERSION 1.6
 
 enum iOptron {IOPTRON_OK=0, NOT_CONNECTED, IOPTRON_CANT_CONNECT, IOPTRON_BAD_CMD_RESPONSE, COMMAND_FAILED, IOPTRON_ERROR};
 

--- a/iOptronV3.h
+++ b/iOptronV3.h
@@ -27,9 +27,9 @@
 #include "StopWatch.h"
 
 
-// #define IOPTRON_DEBUG 3   // define this to have log files, 1 = bad stuff only, 2 and up.. full debug
+#define IOPTRON_DEBUG 1   // define this to have log files, 1 = bad stuff only, 2 and up.. full debug
 
-#define DRIVER_VERSION 1.5
+#define DRIVER_VERSION 1.11
 
 enum iOptron {IOPTRON_OK=0, NOT_CONNECTED, IOPTRON_CANT_CONNECT, IOPTRON_BAD_CMD_RESPONSE, COMMAND_FAILED, IOPTRON_ERROR};
 

--- a/x2mount.h
+++ b/x2mount.h
@@ -35,8 +35,8 @@
 #define MAX_PORT_NAME_SIZE 120
 
 
-#define IOPTRON_X2_DEBUG    // Define this to have log files
-#define IOPTRON_X2_LOG_LEVEL 1
+// #define IOPTRON_X2_DEBUG    // Define this to have log files
+#define IOPTRON_X2_LOG_LEVEL 0
 
 #if defined(SB_WIN_BUILD)
 #define DEF_PORT_NAME					"COM1"

--- a/x2mount.h
+++ b/x2mount.h
@@ -35,7 +35,8 @@
 #define MAX_PORT_NAME_SIZE 120
 
 
-// #define IOPTRON_X2_DEBUG    // Define this to have log files
+#define IOPTRON_X2_DEBUG    // Define this to have log files
+#define IOPTRON_X2_LOG_LEVEL 1
 
 #if defined(SB_WIN_BUILD)
 #define DEF_PORT_NAME					"COM1"


### PR DESCRIPTION
This pull request might be larger than it should be. Let me know if you'd like for me to back some things out.

* Set some log levels to be a bit less chatty
* Fixed a few compiler warnings
* Longitude was being mangled when trying to write back to the mount.  In the debug lines, I was getting:

```
[Sat Nov 26 13:54:15 2022] reading lat/lng from TSX -- lat: XX, lng: 92.334444
[Sat Nov 26 13:54:15 2022] doConfirm called: X2GUIInterface is *good*.  
[Sat Nov 26 13:54:18 2022] doConfirm dialog ended successfully.  value of bPressedOK: true.  
[Sat Nov 26 13:54:18 2022] [CiOptron::setLocation] called 
[Sat Nov 26 13:54:18 2022] [CiOptron::setLocation] setting Longitude from 0.000000 to iOptron value 0
[Sat Nov 26 13:54:18 2022] [CiOptron::setLocation] buffer to send for Long to mount :SLO+00000000#
```

After the fix, in the logs, I get:

```
[Sat Nov 26 14:36:23 2022] [CiOptron::setLocation] setting Longitude from -92.334442 to iOptron value 0
[Sat Nov 26 14:36:23 2022] [CiOptron::setLocation] buffer to send for Long to mount :SLO-33240400#
```

And location is properly synced to the mount.