### PR TITLE
Allow a sync even if there is no GPS.

### DIFF
--- a/iOptronV3.cpp
+++ b/iOptronV3.cpp
@@ -526,11 +526,9 @@ int CiOptron::syncTo(double dRaInDecimalHours, double dDecInDecimalDegrees)
     }
 #endif
 
-    if (m_nGPSStatus != GPS_RECEIVING_VALID_DATA)
-        return ERR_CMDFAILED;
-
-    if(!m_bIsConnected)
+    if(!m_bIsConnected) {
         return NOT_CONNECTED;
+    }
 
     nErr = setRaAndDec("CiOptron::syncTo", dRaInDecimalHours, dDecInDecimalDegrees);
     if (nErr) {


### PR DESCRIPTION
after setting GPS from TheSkyX, we'll still run into GPS_RECEIVING_VALID_DATA, so a sync on star is 
never possible if one doesn't have the optional GPS module.

Got a reasonably clear night to finally test on a RaspberryPi. On bootup, the mount was in 
outer space (pun intended), tried to sync on an imagelink of the home position in order to
start up the initial Tpoint module.

This change allowed me to do that from a cold boot of the mount + startup of TheSky.