### PR TITLE
Support CiOptron::syncTo if there is no GPS module

### DIFF
--- a/iOptronV3.cpp
+++ b/iOptronV3.cpp
@@ -526,11 +526,9 @@ int CiOptron::syncTo(double dRaInDecimalHours, double dDecInDecimalDegrees)
     }
 #endif
 
-    if (m_nGPSStatus != GPS_RECEIVING_VALID_DATA)
-        return ERR_CMDFAILED;
-
-    if(!m_bIsConnected)
+    if(!m_bIsConnected) {
         return NOT_CONNECTED;
+    }
 
     nErr = setRaAndDec("CiOptron::syncTo", dRaInDecimalHours, dDecInDecimalDegrees);
     if (nErr) {


### PR DESCRIPTION
Sorry for the closed PRs. I made a mess of the upstreams. This should be clean here.

With no external GPS module, after setting GPS from TheSkyX, we'll run into GPS_RECEIVING_VALID_DATA, so a sync on star is never possible if one doesn't have the optional GPS module.

I had clear skies to test the mount for tonight, and it was in "outer space" on first boot, so I tried an image link/sync prior to doing my initial TPoint model.

This fix allowed me to do that and start on the model.